### PR TITLE
IME support

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -24,6 +24,7 @@ const ChatInput: FC<Props> = (props) => {
     }
 
     if (
+      !event.nativeEvent.isComposing &&
       keysPressed.has("Enter") &&
       !keysPressed.has("Shift") &&
       buttonRef.current


### PR DESCRIPTION
# Description

When using an Japanese Input Method Editor (IME), the Enter key is used for finalizing character conversion. This conflicts with pressing the Enter key to submit form, and causes premature form submission and frustration for Japanese users who are in the middle of inputting text.

This PR ensures that the Enter key will only send the message if the user is not in the middle of an IME conversion, which should provide a more intuitive experience for users typing in Japanese.

NOTES: not sure but this might also happen in Chinese and Korean language which use IME.

# Solution

I resolve this issue by leveraging the `isComposing` property provided by the keyboard event object. This property returns `true` until IME input ends (i.e., when Enter key is hit to confirm conversion). Therefore, by using this property, we can prevent form submission when Enter key is hit during IME conversion. To be exact, within the `onKeyDown` event handler, we cancel submission by Enter key when `event.nativeEvent.isComposing` is `true` (i.e., during IME conversion). This solves the issue of form submission during Japanese input or other IME inputs.

# Reference

- https://en.wikipedia.org/wiki/Japanese_input_method
- https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing

-----

BTW, I'm not React developer. If my fix is wrong or not enough, I would appreciate it if you could explain what needs to be fixed.