### PR TITLE
Feature: Move extension and personas to config container instead of history

### DIFF
--- a/src/features/extensions-page/extension-services/extension-service.ts
+++ b/src/features/extensions-page/extension-services/extension-service.ts
@@ -15,7 +15,7 @@ import {
   ServerActionResponse,
   zodErrorsToServerActionErrors,
 } from "@/features/common/server-action-response";
-import { HistoryContainer } from "@/features/common/services/cosmos";
+import { ConfigContainer } from "@/features/common/services/cosmos";
 import { AzureKeyVaultInstance } from "@/features/common/services/key-vault";
 import { uniqueId } from "@/features/common/util";
 import { AI_NAME, CHAT_DEFAULT_PERSONA } from "@/features/theme/theme-config";
@@ -46,7 +46,7 @@ export const FindExtensionByID = async (
       ],
     };
 
-    const { resources } = await HistoryContainer()
+    const { resources } = await ConfigContainer()
       .items.query<ExtensionModel>(querySpec)
       .fetchAll();
 
@@ -111,7 +111,7 @@ export const CreateExtension = async (
       await secureHeaderValues(modelToSave);
 
       const { resource } =
-        await HistoryContainer().items.create<ExtensionModel>(modelToSave);
+        await ConfigContainer().items.create<ExtensionModel>(modelToSave);
 
       if (resource) {
         return {
@@ -231,7 +231,7 @@ export const DeleteExtension = async (
         await vault.beginDeleteSecret(h.id);
       });
 
-      const { resource } = await HistoryContainer()
+      const { resource } = await ConfigContainer()
         .item(id, extensionResponse.response.userId)
         .delete<ExtensionModel>();
 
@@ -300,7 +300,7 @@ export const UpdateExtension = async (
         await secureHeaderValues(inputModel);
 
         const { resource } =
-          await HistoryContainer().items.upsert<ExtensionModel>(inputModel);
+          await ConfigContainer().items.upsert<ExtensionModel>(inputModel);
 
         if (resource) {
           return {
@@ -358,7 +358,7 @@ export const FindAllExtensionForCurrentUser = async (): Promise<
       ],
     };
 
-    const { resources } = await HistoryContainer()
+    const { resources } = await ConfigContainer()
       .items.query<ExtensionModel>(querySpec)
       .fetchAll();
 

--- a/src/features/persona-page/persona-services/persona-service.ts
+++ b/src/features/persona-page/persona-services/persona-service.ts
@@ -11,7 +11,7 @@ import {
   ServerActionResponse,
   zodErrorsToServerActionErrors,
 } from "@/features/common/server-action-response";
-import { HistoryContainer } from "@/features/common/services/cosmos";
+import { ConfigContainer } from "@/features/common/services/cosmos";
 import { uniqueId } from "@/features/common/util";
 import { SqlQuerySpec } from "@azure/cosmos";
 import { PERSONA_ATTRIBUTE, PersonaModel, PersonaModelSchema } from "./models";
@@ -41,7 +41,7 @@ export const FindPersonaByID = async (
       ],
     };
 
-    const { resources } = await HistoryContainer()
+    const { resources } = await ConfigContainer()
       .items.query<PersonaModel>(querySpec)
       .fetchAll();
 
@@ -95,7 +95,7 @@ export const CreatePersona = async (
       return valid;
     }
 
-    const { resource } = await HistoryContainer().items.create<PersonaModel>(
+    const { resource } = await ConfigContainer().items.create<PersonaModel>(
       modelToSave
     );
 
@@ -156,7 +156,7 @@ export const DeletePersona = async (
     const personaResponse = await EnsurePersonaOperation(personaId);
 
     if (personaResponse.status === "OK") {
-      const { resource: deletedPersona } = await HistoryContainer()
+      const { resource: deletedPersona } = await ConfigContainer()
         .item(personaId, personaResponse.response.userId)
         .delete();
 
@@ -205,7 +205,7 @@ export const UpsertPersona = async (
         return validationResponse;
       }
 
-      const { resource } = await HistoryContainer().items.upsert<PersonaModel>(
+      const { resource } = await ConfigContainer().items.upsert<PersonaModel>(
         modelToUpdate
       );
 
@@ -262,7 +262,7 @@ export const FindAllPersonaForCurrentUser = async (): Promise<
       ],
     };
 
-    const { resources } = await HistoryContainer()
+    const { resources } = await ConfigContainer()
       .items.query<PersonaModel>(querySpec)
       .fetchAll();
 


### PR DESCRIPTION
This pull request includes changes to replace the use of `HistoryContainer` with `ConfigContainer` in the `extension-service.ts` and `persona-service.ts` files. This update affects multiple functions across both files.

Changes to `extension-service.ts`:

* Replaced `HistoryContainer` with `ConfigContainer` in the import statement.
* Updated the `FindExtensionByID` function to use `ConfigContainer` for querying extensions.
* Modified the `CreateExtension` function to use `ConfigContainer` for creating extensions.
* Changed the `DeleteExtension` function to use `ConfigContainer` for deleting extensions.
* Updated the `UpdateExtension` function to use `ConfigContainer` for upserting extensions.
* Modified the `FindAllExtensionForCurrentUser` function to use `ConfigContainer` for querying all extensions for the current user.

Changes to `persona-service.ts`:

* Replaced `HistoryContainer` with `ConfigContainer` in the import statement.
* Updated the `FindPersonaByID` function to use `ConfigContainer` for querying personas.
* Modified the `CreatePersona` function to use `ConfigContainer` for creating personas.
* Changed the `DeletePersona` function to use `ConfigContainer` for deleting personas.
* Updated the `UpsertPersona` function to use `ConfigContainer` for upserting personas.
* Modified the `FindAllPersonaForCurrentUser` function to use `ConfigContainer` for querying all personas for the current user.