### PR TITLE
add deep linking to a new persona chat

### DIFF
--- a/src/app/(authenticated)/chat/create/persona/[id]/loading.tsx
+++ b/src/app/(authenticated)/chat/create/persona/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoader } from "@/features/ui/page-loader";
+
+export default function Loading() {
+    return <PageLoader />;
+}

--- a/src/app/(authenticated)/chat/create/persona/[id]/page.tsx
+++ b/src/app/(authenticated)/chat/create/persona/[id]/page.tsx
@@ -1,0 +1,26 @@
+import { DisplayError } from "@/features/ui/error/display-error";
+import {
+    CreatePersonaChat,
+    FindPersonaForCurrentUser
+} from "@/features/persona-page/persona-services/persona-service";
+import {RedirectToChatThread} from "@/features/common/navigation-helpers";
+
+interface HomeParams {
+    params: {
+        id: string;
+    };
+}
+
+export default async function Home(props: HomeParams) {
+    const { id } = props.params;
+    const personaResponse = await FindPersonaForCurrentUser(id);
+    if (personaResponse.status !== "OK") {
+        return <DisplayError errors={personaResponse.errors} />;
+    }
+    const response = await CreatePersonaChat(id);
+    if (response.status === "OK") {
+        RedirectToChatThread(response.response.id);
+    } else {
+        return <DisplayError errors={response.errors} />;
+    }
+}

--- a/src/features/persona-page/persona-card/copy-start-new-persona-chat.tsx
+++ b/src/features/persona-page/persona-card/copy-start-new-persona-chat.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { Button } from "@/features/ui/button";
+import {ClipboardCheckIcon, LinkIcon} from "lucide-react";
+import {FC, useEffect, useState} from "react";
+
+interface Props {
+    id: string;
+}
+
+export const CopyStartNewPersonaChat: FC<Props> = (props) => {
+    const id = props.id;
+    const [hostUrl, setHostUrl] = useState("");
+    const [isIconChecked, setIsIconChecked] = useState(false);
+
+    useEffect(() => {
+        if (id) {
+            setHostUrl(window.location.origin);
+        }
+    }, [id]);
+
+    const handleButtonClick = () => {
+        if(hostUrl && id) {
+            const urlToCopy = `${hostUrl}/chat/create/persona/${id}`
+            navigator.clipboard.writeText(urlToCopy).then(() => {setIsIconChecked(true);});
+        }
+    };
+
+    return (
+        <Button
+            variant={"outline"}
+            title="Copy start chat url"
+            onClick={handleButtonClick}
+        >
+            {isIconChecked ? (
+                <ClipboardCheckIcon size={18} />
+            ) : (
+                <LinkIcon size={18} />
+            )}
+        </Button>
+    );
+};

--- a/src/features/persona-page/persona-card/persona-card.tsx
+++ b/src/features/persona-page/persona-card/persona-card.tsx
@@ -10,6 +10,7 @@ import { PersonaModel } from "../persona-services/models";
 import { PersonaCardContextMenu } from "./persona-card-context-menu";
 import { ViewPersona } from "./persona-view";
 import { StartNewPersonaChat } from "./start-new-persona-chat";
+import {CopyStartNewPersonaChat} from "@/features/persona-page/persona-card/copy-start-new-persona-chat";
 
 interface Props {
   persona: PersonaModel;
@@ -33,7 +34,7 @@ export const PersonaCard: FC<Props> = (props) => {
       </CardContent>
       <CardFooter className="gap-1 content-stretch f">
         {props.showContextMenu && <ViewPersona persona={persona} />}
-
+        <CopyStartNewPersonaChat id={persona.id} />
         <StartNewPersonaChat persona={persona} />
       </CardFooter>
     </Card>

--- a/src/features/persona-page/persona-services/persona-service.ts
+++ b/src/features/persona-page/persona-services/persona-service.ts
@@ -239,6 +239,60 @@ export const UpsertPersona = async (
   }
 };
 
+export const FindPersonaForCurrentUser = async (
+    id: string
+): Promise<ServerActionResponse<PersonaModel>> => {
+  try {
+    const querySpec: SqlQuerySpec = {
+      query:
+          "SELECT * FROM root r WHERE r.type=@type AND (r.isPublished=@isPublished OR r.userId=@userId) AND r.id=@id",
+      parameters: [
+        {
+          name: "@type",
+          value: PERSONA_ATTRIBUTE,
+        },
+        {
+          name: "@isPublished",
+          value: true,
+        },
+        {
+          name: "@userId",
+          value: await userHashedId(),
+        },
+        {
+          name: "@id",
+          value: id,
+        },
+      ],
+    };
+
+    const { resources } = await HistoryContainer()
+        .items.query<PersonaModel>(querySpec)
+        .fetchAll();
+
+    if (resources.length === 0) {
+      return {
+        status: "NOT_FOUND",
+        errors: [{ message: `Persona not found. Please ensure the persona exists and is published for your account.` }],
+      };
+    }
+
+    return {
+      status: "OK",
+      response: resources[0],
+    };
+  } catch (error) {
+    return {
+      status: "ERROR",
+      errors: [
+        {
+          message: `Error finding persona: ${error}`,
+        },
+      ],
+    };
+  }
+};
+
 export const FindAllPersonaForCurrentUser = async (): Promise<
   ServerActionResponse<Array<PersonaModel>>
 > => {


### PR DESCRIPTION
This PR streamlines persona chat creation by introducing a routable endpoint, allowing users to bookmark and share direct links to new chats with specific personas. A new button for copying the URL ensures easy access and sharing. Importantly, users can only create persona chats where they have the necessary access rights for that specific persona.